### PR TITLE
feat: Add bin field to package.json and fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.4.0",
   "description": "A job search and crawling tool built with Model Context Protocol",
   "main": "dist/index.js",
+  "bin": {
+    "mcp-jobs": "./dist/index.js"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
Added the "bin" field to the `package.json` file to allow the package to be executed from the command line.

Also installed all the necessary dependencies for Playwright to run correctly.